### PR TITLE
added homing behavior for the ship

### DIFF
--- a/Assets/Scenes/DemoLevel.unity
+++ b/Assets/Scenes/DemoLevel.unity
@@ -132,6 +132,8 @@ GameObject:
   - component: {fileID: 849789757}
   - component: {fileID: 849789756}
   - component: {fileID: 849789755}
+  - component: {fileID: 849789759}
+  - component: {fileID: 849789758}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -217,6 +219,58 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!50 &849789758
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849789754}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!60 &849789759
+PolygonCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849789754}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 0.5, y: 0.5}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Points:
+    m_Paths:
+    - - {x: -0.03125, y: 0.25}
+      - {x: -0.25, y: -0.1796875}
+      - {x: -0.25, y: -0.25}
+      - {x: 0.25, y: -0.25}
+      - {x: 0.25, y: -0.1953125}
+      - {x: 0.0234375, y: 0.25}
 --- !u!1 &1822518174
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Ship.cs
+++ b/Assets/Scripts/Ship.cs
@@ -6,7 +6,10 @@ public class Ship : MonoBehaviour
 {
     private const double ShotInterval = 2;
     private Timer ShotTimer;
+    private Rigidbody2D ShipRigidbody;
     public GameObject LaserPrefab;
+    private const float MinRotationSpeed = 200f, MaxRotationSpeed = 600f, BaseMovementSpeed = 5f, MaxMovementSpeed = 7.5f;
+    private bool IsMoving;
 
     private void Start()
     {
@@ -21,7 +24,12 @@ public class Ship : MonoBehaviour
         {
             FireShot();
         }
-        FaceCursor();
+        ChaseMouse();
+    }
+
+    private void Awake()
+    {
+        ShipRigidbody = GetComponent<Rigidbody2D>();
     }
 
     public void FireShot() 
@@ -37,5 +45,55 @@ public class Ship : MonoBehaviour
         float theta = 360 - Mathf.Atan2(mousePosition.x - transform.position.x, mousePosition.y - transform.position.y) * 180 / Mathf.PI;
         theta = (theta + 360) % 360;
         transform.eulerAngles = new Vector3(0f, 0f, theta);
+    }
+
+    public void ChaseMouse() 
+    {
+        // The basis of the math in this method comes from https://www.youtube.com/watch?v=0v_H3oOR0aU.
+        Vector3 mousePosition = Camera.main.ScreenToWorldPoint(Input.mousePosition);
+        Vector2 direction = (Vector2) mousePosition - (Vector2) transform.position;
+
+        direction.Normalize();
+        float rotationCorrection = Vector3.Cross(direction, transform.up).z;
+
+        // My own math for variable speed and angular adjustment
+        Vector2 distanceToMouse = transform.position - mousePosition;
+        float movementSpeed, rotationSpeed;
+
+        // if mouse close to ship, stop moving and start adjusting angle quickly. This will stop the ship until the user moves the mouse far away again
+        if (distanceToMouse.magnitude < 1f) 
+        {
+            movementSpeed = 0f;
+            rotationSpeed = MaxRotationSpeed;
+            IsMoving = false;         
+        }
+        else 
+        {
+            // if in motion, give movement speed and slower angular speed
+            if (IsMoving) 
+            {
+                movementSpeed = Mathf.Clamp(BaseMovementSpeed * distanceToMouse.magnitude, -MaxMovementSpeed, MaxMovementSpeed);
+                rotationSpeed = MinRotationSpeed;
+            }
+            else 
+            {
+                // mouse needs to go farther away to start the movement again
+                if (distanceToMouse.magnitude > 1f)
+                {
+                    IsMoving = true;
+                    movementSpeed = Mathf.Clamp(BaseMovementSpeed * distanceToMouse.magnitude, -MaxMovementSpeed, MaxMovementSpeed);
+                    rotationSpeed = MinRotationSpeed;
+                }
+                // if not past the threshold, keep using the fast angle adjustment with no movement
+                else 
+                {
+                    movementSpeed = 0f;
+                    rotationSpeed = MaxRotationSpeed;
+                }
+            }
+        }
+
+        ShipRigidbody.angularVelocity = -rotationCorrection * rotationSpeed;
+        ShipRigidbody.velocity = transform.up * movementSpeed;
     }
 }


### PR DESCRIPTION
The ship will now chase the cursor, adjusting its angle and position to get closer to the mouse position. As of right now, the ship will start up with a burst of speed when movement begins, which would ideally be a slower startup process with acceleration. 

The ship has two modes of movement:
* Stationary, course correction mode (quicker turns, but mouse must be on ship)
* Moving, with slower angular movements (takes wider turns)

Ideally, there would be an accelerating period from stationary to moving and a decelerating period from moving to stationary in order to prevent players from staying as close to the front of the ship as possible.